### PR TITLE
Add pulse valve stimulus for passive and operant trials

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ This stimulus type implements visual stimulation with an arbitrary image sequenc
     * **Onset** the delay until the video appears, in seconds
     * **Duration** the time during which the video is visible, in seconds
 
+#### Pulse Valve
+
+This stimulus type implements a single pulse on the water valve output. Pulse duration must be specified manually in the Behavior board GUI.
+
+* **`/pulseValve`** (no arguments)
+
 #### Start
 
 This message immediately plays the current stimulus set as a passive stimulation trial.

--- a/src/matlab/Rig.m
+++ b/src/matlab/Rig.m
@@ -77,6 +77,10 @@ classdef Rig
                    onset, duration);
     end
 
+    function pulseValve(obj)
+      obj.osc.send('/pulseValve', ',i', 0);
+    end
+
     function start(obj)
       obj.osc.send('/start', ',i', 0);
     end

--- a/src/python/osc-test.py
+++ b/src/python/osc-test.py
@@ -42,11 +42,14 @@ try:
     rig.receive()  # Wait for end trial
     
     rig.experiment(metadata)
+    rig.pulseValve() # Configure pulse
+    rig.success() # Pulse valve on hit trial
     rig.gratings(width=120, height=120, angle=30, freq=0.1, duration=2.0) # go gratings
     rig.go(suppress=1000, start=500, duration=1000.0, threshold=2) # go trial
     rig.receive()  # Wait for end trial
 
     rig.experiment(metadata)
+    rig.success() # Configure no-reward for correct reject trial
     rig.gratings(width=120, height=120, angle=0, freq=0.1, duration=2.0) # nogo gratings
     rig.nogo(suppress=500, start=0.0, duration=2000.0) # no-go trial
     rig.receive()  # Wait for end trial

--- a/src/python/rigstim.py
+++ b/src/python/rigstim.py
@@ -95,6 +95,9 @@ class RigClient:
                    [loop,speed,name],
                    [onset,duration]])
     
+    def pulseValve(self):
+        self.send("/pulseValve", 0)
+    
     def start(self):
         self.send("/start", 0)
         

--- a/src/workflows/Extensions/PulseValve.bonsai
+++ b/src/workflows/Extensions/PulseValve.bonsai
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.5"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="rx:CreateObservable">
+        <Name>PulseValve</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>PulseValve</Name>
+            </Expression>
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/workflows/ranson-rig.bonsai
+++ b/src/workflows/ranson-rig.bonsai
@@ -578,6 +578,14 @@ Item3.Item1 as Onset,
 Item3.Item2 as Duration)</scr:Expression>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Extensions\VideoStimulus.bonsai" />
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Request</Name>
+            </Expression>
+            <Expression xsi:type="osc:Parse">
+              <osc:Address>/pulseValve</osc:Address>
+              <osc:TypeTag />
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Extensions\PulseValve.bonsai" />
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:Merge" />
             </Expression>
@@ -713,36 +721,39 @@ Item3.Item2 as Duration)</scr:Expression>
             <Edge From="8" To="9" Label="Source1" />
             <Edge From="9" To="10" Label="Source1" />
             <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="16" Label="Source1" />
+            <Edge From="11" To="19" Label="Source1" />
             <Edge From="12" To="13" Label="Source1" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="16" Label="Source2" />
-            <Edge From="16" To="19" Label="Source1" />
+            <Edge From="15" To="19" Label="Source2" />
+            <Edge From="16" To="17" Label="Source1" />
             <Edge From="17" To="18" Label="Source1" />
-            <Edge From="18" To="19" Label="Source2" />
-            <Edge From="19" To="20" Label="Source1" />
-            <Edge From="21" To="22" Label="Source1" />
+            <Edge From="18" To="19" Label="Source3" />
+            <Edge From="19" To="22" Label="Source1" />
+            <Edge From="20" To="21" Label="Source1" />
+            <Edge From="21" To="22" Label="Source2" />
             <Edge From="22" To="23" Label="Source1" />
-            <Edge From="23" To="24" Label="Source1" />
             <Edge From="24" To="25" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
+            <Edge From="26" To="27" Label="Source1" />
             <Edge From="27" To="28" Label="Source1" />
             <Edge From="28" To="29" Label="Source1" />
-            <Edge From="29" To="30" Label="Source1" />
             <Edge From="30" To="31" Label="Source1" />
             <Edge From="31" To="32" Label="Source1" />
+            <Edge From="32" To="33" Label="Source1" />
             <Edge From="33" To="34" Label="Source1" />
-            <Edge From="34" To="36" Label="Source1" />
-            <Edge From="35" To="36" Label="Source2" />
+            <Edge From="34" To="35" Label="Source1" />
             <Edge From="36" To="37" Label="Source1" />
-            <Edge From="37" To="38" Label="Source1" />
-            <Edge From="38" To="39" Label="Source1" />
+            <Edge From="37" To="39" Label="Source1" />
+            <Edge From="38" To="39" Label="Source2" />
+            <Edge From="39" To="40" Label="Source1" />
             <Edge From="40" To="41" Label="Source1" />
             <Edge From="41" To="42" Label="Source1" />
-            <Edge From="42" To="43" Label="Source1" />
             <Edge From="43" To="44" Label="Source1" />
             <Edge From="44" To="45" Label="Source1" />
+            <Edge From="45" To="46" Label="Source1" />
+            <Edge From="46" To="47" Label="Source1" />
+            <Edge From="47" To="48" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/workflows/ranson-rig.bonsai.layout
+++ b/src/workflows/ranson-rig.bonsai.layout
@@ -221,11 +221,11 @@
       <Visible>false</Visible>
       <Location>
         <X>4</X>
-        <Y>4</Y>
+        <Y>5</Y>
       </Location>
       <Size>
-        <Width>1019</Width>
-        <Height>707</Height>
+        <Width>1294</Width>
+        <Height>762</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -269,11 +269,11 @@
       <Visible>false</Visible>
       <Location>
         <X>4</X>
-        <Y>4</Y>
+        <Y>5</Y>
       </Location>
       <Size>
-        <Width>1019</Width>
-        <Height>707</Height>
+        <Width>1294</Width>
+        <Height>762</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>


### PR DESCRIPTION
Reward delivery was previously supported only in corridor trials. This PR extends support for passive and operant trials, building up on the concept of success and failure stimulus sets. Pulse valve may now be configured as a general stimulus type which can be added contingent on trial outcome.

For example, to configure a go trial with pulse on hit:

```python
    rig.experiment(metadata)
    rig.pulseValve() # Configure pulse
    rig.success() # Pulse valve on hit trial
    rig.gratings(width=120, height=120, angle=30, freq=0.1, duration=2.0) # go gratings
    rig.go(suppress=1000, start=500, duration=1000.0, threshold=2) # go trial
    rig.receive()  # Wait for end trial
```

Conversely, to configure a no-go trial with no reward on correct reject:

```python
    rig.experiment(metadata)
    rig.success() # Configure no-reward for correct reject trial
    rig.gratings(width=120, height=120, angle=0, freq=0.1, duration=2.0) # nogo gratings
    rig.nogo(suppress=500, start=0.0, duration=2000.0) # no-go trial
    rig.receive()  # Wait for end trial
```