### PR TITLE
Add success stimulus playback for passive trials

### DIFF
--- a/src/workflows/Extensions/PlayStimulus.bonsai
+++ b/src/workflows/Extensions/PlayStimulus.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.4"
+<WorkflowBuilder Version="2.8.5"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns="https://bonsai-rx.org/2018/workflow">
@@ -7,6 +7,9 @@
     <Nodes>
       <Expression xsi:type="WorkflowInput">
         <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="StimulusBank" />
       </Expression>
       <Expression xsi:type="rx:SelectMany">
         <Name>PlayStimulus</Name>
@@ -47,6 +50,9 @@
             <Expression xsi:type="WorkflowInput">
               <Name>Source1</Name>
             </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Name" DisplayName="StimulusBank" />
+            </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>Stimuli</Name>
             </Expression>
@@ -76,21 +82,23 @@
             <Edge From="3" To="4" Label="Source1" />
             <Edge From="4" To="5" Label="Source2" />
             <Edge From="5" To="6" Label="Source1" />
-            <Edge From="7" To="13" Label="Source1" />
+            <Edge From="7" To="14" Label="Source1" />
             <Edge From="8" To="9" Label="Source1" />
             <Edge From="9" To="10" Label="Source1" />
             <Edge From="10" To="11" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source2" />
-            <Edge From="13" To="14" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="13" To="14" Label="Source2" />
+            <Edge From="14" To="15" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="1" Label="Source1" />
-      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="0" To="2" Label="Source1" />
+      <Edge From="1" To="2" Label="Source2" />
+      <Edge From="2" To="3" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/workflows/ranson-rig.bonsai
+++ b/src/workflows/ranson-rig.bonsai
@@ -775,7 +775,12 @@ Item3.Item2 as Duration)</scr:Expression>
               <Combinator xsi:type="gl:SampleOnUpdateFrame" />
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Extensions\StartTrial.bonsai" />
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\PlayStimulus.bonsai" />
+            <Expression xsi:type="IncludeWorkflow" Path="Extensions\PlayStimulus.bonsai">
+              <StimulusBank>Stimuli</StimulusBank>
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Extensions\PlayStimulus.bonsai">
+              <StimulusBank>Success</StimulusBank>
+            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="IntProperty">
                 <Value>0</Value>
@@ -803,6 +808,7 @@ Item3.Item2 as Duration)</scr:Expression>
             <Edge From="8" To="9" Label="Source1" />
             <Edge From="9" To="10" Label="Source1" />
             <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="12" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
Passive trials were not currently configured to playback any stimulus. This PR adds playback of the success stimulus bank by default on passive trials.

To configure a passive trial with pulse at the end:

```python
    rig.experiment(metadata)
    rig.pulseValve() # Configure pulse
    rig.success() # Pulse valve on end of passive trial
    rig.gratings(width=30, height=30, x=-15, y=-5, angle=0, freq=0.1, duration=2.0) # grating 1
    rig.gratings(width=15, height=15, x=15, y=-5, angle=45, freq=0.1, duration=2.0, speed=1) # grating 2
    rig.video("Blink", y=20, speed=2.0, onset=1.0, duration=2.0) # video 1
    rig.start()
    rig.receive()  # Wait for end trial
```

One word of caution is that the "success" stimulus is global shared state across passive/go/no-go trials. If you need the same success stimulus for all trials, you can configure it once at the beginning of the session and never touch it again.

However, if you need some "success" outcomes to have either no reward, or different reward parameters or types, then you may need to modify the success stimulus at trial definition, which is why I have been adding it to the body of the trial configuration block on every trial.