### PR TITLE
Configure encoder mode to avoid angle wrapping

### DIFF
--- a/src/workflows/Extensions/HarpRig.bonsai
+++ b/src/workflows/Extensions/HarpRig.bonsai
@@ -1,15 +1,45 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <WorkflowBuilder Version="2.8.5"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:p1="clr-namespace:Bonsai.Harp.CF;assembly=Bonsai.Harp.CF"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
-      <Expression xsi:type="rx:BehaviorSubject" TypeArguments="harp:HarpMessage">
-        <rx:Name>Command</rx:Name>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>ConfigureEncoderMode</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="ByteProperty">
+                <Value>1</Value>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="harp:Format">
+              <harp:MessageType>Write</harp:MessageType>
+              <harp:Register xsi:type="harp:FormatMessagePayload">
+                <harp:Address>83</harp:Address>
+                <harp:PayloadType>U8</harp:PayloadType>
+              </harp:Register>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Command</Name>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="PortName" />
@@ -43,6 +73,16 @@
           <Value>1</Value>
         </Operand>
       </Expression>
+      <Expression xsi:type="rx:Accumulate" />
+      <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Object">
+        <rx:Name>ResetEncoder</rx:Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:TakeUntil" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Repeat" />
+      </Expression>
       <Expression xsi:type="rx:PublishSubject">
         <Name>RigEncoder</Name>
       </Expression>
@@ -75,19 +115,6 @@
       <Expression xsi:type="p1:BehaviorCommand">
         <p1:Type>SetOutput</p1:Type>
         <p1:Mask>Port0</p1:Mask>
-      </Expression>
-      <Expression xsi:type="MulticastSubject">
-        <Name>Command</Name>
-      </Expression>
-      <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Object">
-        <rx:Name>ResetEncoder</rx:Name>
-      </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Mask" DisplayName="EncoderPort" Category="Wiring" />
-      </Expression>
-      <Expression xsi:type="p1:BehaviorCommand">
-        <p1:Type>ResetQuadratureCounter</p1:Type>
-        <p1:Mask>Port2</p1:Mask>
       </Expression>
       <Expression xsi:type="MulticastSubject">
         <Name>Command</Name>
@@ -157,33 +184,35 @@
       </Expression>
     </Nodes>
     <Edges>
-      <Edge From="0" To="2" Label="Source1" />
-      <Edge From="1" To="2" Label="Source2" />
-      <Edge From="2" To="3" Label="Source1" />
-      <Edge From="4" To="5" Label="Source1" />
-      <Edge From="5" To="7" Label="Source1" />
-      <Edge From="6" To="7" Label="Source2" />
-      <Edge From="7" To="8" Label="Source1" />
-      <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="3" Label="Source1" />
+      <Edge From="2" To="3" Label="Source2" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="11" Label="Source1" />
+      <Edge From="10" To="11" Label="Source2" />
+      <Edge From="11" To="12" Label="Source1" />
       <Edge From="12" To="13" Label="Source1" />
-      <Edge From="13" To="14" Label="Source1" />
-      <Edge From="15" To="17" Label="Source1" />
-      <Edge From="16" To="17" Label="Source2" />
+      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
       <Edge From="17" To="18" Label="Source1" />
-      <Edge From="19" To="21" Label="Source1" />
-      <Edge From="20" To="21" Label="Source2" />
-      <Edge From="21" To="22" Label="Source1" />
-      <Edge From="23" To="24" Label="Source1" />
+      <Edge From="18" To="19" Label="Source1" />
+      <Edge From="20" To="22" Label="Source1" />
+      <Edge From="21" To="22" Label="Source2" />
+      <Edge From="22" To="23" Label="Source1" />
       <Edge From="24" To="25" Label="Source1" />
-      <Edge From="24" To="28" Label="Source1" />
-      <Edge From="25" To="27" Label="Source1" />
-      <Edge From="26" To="27" Label="Source2" />
-      <Edge From="26" To="29" Label="Source2" />
-      <Edge From="27" To="30" Label="Source1" />
-      <Edge From="28" To="29" Label="Source1" />
-      <Edge From="29" To="30" Label="Source2" />
-      <Edge From="30" To="31" Label="Source1" />
+      <Edge From="25" To="26" Label="Source1" />
+      <Edge From="25" To="29" Label="Source1" />
+      <Edge From="26" To="28" Label="Source1" />
+      <Edge From="27" To="28" Label="Source2" />
+      <Edge From="27" To="30" Label="Source2" />
+      <Edge From="28" To="31" Label="Source1" />
+      <Edge From="29" To="30" Label="Source1" />
+      <Edge From="30" To="31" Label="Source2" />
+      <Edge From="31" To="32" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/workflows/ranson-rig.bonsai
+++ b/src/workflows/ranson-rig.bonsai
@@ -1194,7 +1194,6 @@ Item6 as ViewPosition)</scr:Expression>
         <PortName>COM3</PortName>
         <EncoderScale>1</EncoderScale>
         <ValvePort>Port0</ValvePort>
-        <EncoderPort>Port2</EncoderPort>
         <SyncOutput>Digital0</SyncOutput>
       </Expression>
     </Nodes>


### PR DESCRIPTION
The quadrature counter in the Behavior board can operate in either position or displacement mode. In position mode, the limited resolution of the 16-bit counter value can cause the position value to overflow for very high values.

In this PR we instead configure the encoder to operate in displacement mode, and do the integration in software following a scale change to a 32-bit floating point representation.

Fixes #68 
Fixes #72 