### PR TITLE
Increase minimum time for photodiode sync toggle

### DIFF
--- a/src/workflows/ranson-rig.bonsai
+++ b/src/workflows/ranson-rig.bonsai
@@ -360,7 +360,7 @@ Item2.Index as TrialID)</scr:Expression>
                   <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogExperiment.bonsai">
                     <Seed>0</Seed>
                     <P>1</P>
-                    <Offset>30</Offset>
+                    <Offset>120</Offset>
                   </Expression>
                   <Expression xsi:type="SubscribeSubject">
                     <Name>Prefix</Name>


### PR DESCRIPTION
The photodiode sync sequence is controller by a pseudo-random number sampled from a geometric distribution representing the minimum number of update cycles required between toggles of the sync pulse. The output of this random sequence is bounded by a minimum specified in the `Offset` parameter.

Assuming the current update rate of 120 Hz, the current minimum value of 30 should translate to around ~250ms, which should be plenty to avoid excessively fast "masked" pulsing, but perhaps there is some extra delays at trial load time complicating these calculations, so here we increase the minimum offset to 120.